### PR TITLE
feat: add the tryLoad method

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,94 +1,145 @@
-import crypto, { KeyObject } from 'crypto';
+import crypto, { BinaryLike, Cipher, CipherGCM, Decipher, DecipherGCM, KeyObject } from 'crypto';
 import { promisify } from 'util';
 import {
     FILE_TYPE, load, save,
 } from './file.js';
 
+const ASYMMETRIC_KEYS_ALGO   = 'rsa';
+const ASYMMETRIC_KEYS_CIPHER = 'aes-256-cbc';
+const ASYMMETRIC_KEYS_LENGTH = 4096;
 
-const ASYMMETRIC_KEYS_OPTION = {
-    modulusLength: 4096,
-};
+const ASYMMETRIC_KEYS_FORMAT = {
+    format: 'pem',
+    type:   'pkcs8'
+} as const;
 
+const SYMMETRIC_ALGO = 'aes-256-gcm';
+
+// NOTE: AES-256 requires a 256 bit key. 256 bits === 32 bytes
 const PASSPHRASE_SIZE = 32;
 
-type KeyGenResults = {
-    passphrase: string;
+type KeyPair = {
     privateKey: KeyObject;
-    publicKey: KeyObject;
+    publicKey:  KeyObject;
 };
 
-class KeyChain {
-    public generatePrivateKey (): Promise<KeyObject> {
-        return this._load();
+type EncryptionContext = {
+    nonce:      Buffer;
+    passphrase: Buffer;
+};
+
+type DecryptionContext = EncryptionContext & {
+    authTag: Buffer;
+};
+
+const generateKeyPair = promisify(crypto.generateKeyPair);
+const randomBytes     = promisify(crypto.randomBytes);
+const scrypt          = promisify<BinaryLike, BinaryLike, number, Buffer>(crypto.scrypt);
+
+export default class CryptoContext {
+    async _generateNonce () {
+        return await randomBytes(PASSPHRASE_SIZE);
     }
 
-    public generatePublicKey (): Promise<KeyObject> {
-        return this._generate();
+    async _generateKeyPair (): Promise<KeyPair> {
+        return await generateKeyPair(ASYMMETRIC_KEYS_ALGO, { modulusLength: ASYMMETRIC_KEYS_LENGTH });
     }
 
-    async _generatePassphrase (): Promise<string> {
-        const bytes = await promisify(crypto.randomBytes)(PASSPHRASE_SIZE);
+    async _generatePassphrase (nonce: Buffer): Promise<Buffer> {
+        const bytes = await randomBytes(PASSPHRASE_SIZE);
 
-        return bytes.toString('base64');
+        return await scrypt(bytes, nonce, PASSPHRASE_SIZE);
     }
 
-    async _generateKeyPair (): Promise<KeyGenResults> {
-        const passphrase = await this._generatePassphrase();
-
-        const { publicKey, privateKey } = await promisify(crypto.generateKeyPair)('rsa', ASYMMETRIC_KEYS_OPTION);
-
-        return { passphrase, privateKey, publicKey };
+    private async _saveNonce(nonce: Buffer) {
+        await save(FILE_TYPE.NONCE, nonce);
     }
 
-    async _loadPassphrase (): Promise<string> {
-        const data = await load(FILE_TYPE.PASSPHRASE);
-
-        return data.toString('base64');
-    }
-
-    async _savePassphrase (passphrase: string): Promise<void> {
-        await save(FILE_TYPE.PASSPHRASE, Buffer.from(passphrase, 'base64'));
-    }
-
-    async _loadPrivateKey (passphrase: string): Promise<KeyObject> {
-        const data = await load(FILE_TYPE.PRIVATE_KEY);
-
-        return crypto.createPrivateKey({ key: data, format: 'pem', type: 'pkcs8', passphrase });
-    }
-
-    async _savePrivateKey (privateKey: KeyObject, passphrase: string): Promise<void> {
-        const data = privateKey.export({ format: 'pem', type: 'pkcs8', cipher: 'aes-256-cbc', passphrase });
+    async _savePrivateKey (privateKey: KeyObject, nonce: Buffer): Promise<void> {
+        const data = privateKey.export({ cipher: ASYMMETRIC_KEYS_CIPHER, passphrase: nonce, ...ASYMMETRIC_KEYS_FORMAT });
 
         await save(FILE_TYPE.PRIVATE_KEY, data);
     }
 
-    async _load (): Promise<KeyObject> {
-        const passphrase = await this._loadPassphrase();
-
-        return await this._loadPrivateKey(passphrase);
+    async _savePassphrase (passphrase: Buffer, publicKey: KeyObject): Promise<void> {
+        await save(FILE_TYPE.PASSPHRASE, crypto.publicEncrypt(publicKey, passphrase));
     }
 
-    async _generate (): Promise<KeyObject> {
-        const { passphrase, publicKey, privateKey } = await this._generateKeyPair();
-
-        await this._savePassphrase(passphrase);
-        await this._savePrivateKey(privateKey, passphrase);
-
-        return publicKey;
+    async _saveAuthTag (authTag: Buffer) {
+        await save(FILE_TYPE.AUTH_TAG, authTag);
     }
-}
 
-export default class CryptoContext {
-    constructor (
-        private keys: KeyChain = new KeyChain()
-    ) {
+    async _loadAuthTag () {
+        return await load(FILE_TYPE.AUTH_TAG);
+    }
+
+    private async _loadNonce() {
+        return await load(FILE_TYPE.NONCE);
+    }
+
+    async _loadPrivateKey (nonce: Buffer): Promise<KeyObject> {
+        const data = await load(FILE_TYPE.PRIVATE_KEY);
+
+        return crypto.createPrivateKey({ key: data, passphrase: nonce, ...ASYMMETRIC_KEYS_FORMAT });
+    }
+
+    async _loadPassphrase (privateKey: KeyObject): Promise<Buffer> {
+        const data = await load(FILE_TYPE.PASSPHRASE);
+
+        return crypto.privateDecrypt(privateKey, data);
+    }
+
+    async _generateEncryptionKeys (): Promise<EncryptionContext> {
+        const nonce      = await this._generateNonce();
+        const passphrase = await this._generatePassphrase(nonce);
+
+        const { publicKey, privateKey } = await this._generateKeyPair();
+
+        await this._saveNonce(nonce);
+        await this._savePrivateKey(privateKey, nonce);
+        await this._savePassphrase(passphrase, publicKey);
+
+        return { nonce, passphrase };
+    }
+
+    async _loadDecryptionKeys (): Promise<DecryptionContext> {
+        const authTag    = await this._loadAuthTag();
+        const nonce      = await this._loadNonce();
+        const privateKey = await this._loadPrivateKey(nonce);
+        const passphrase = await this._loadPassphrase(privateKey);
+
+        return { authTag, nonce, passphrase };
+    }
+
+    private async _createCipher (): Promise<CipherGCM> {
+        const { nonce, passphrase } = await this._generateEncryptionKeys();
+
+        return crypto.createCipheriv(SYMMETRIC_ALGO, passphrase, nonce);
+    }
+
+    private async _createDecipher (): Promise<DecipherGCM> {
+        const { nonce, passphrase, authTag } = await this._loadDecryptionKeys();
+
+        const decipher = await crypto.createDecipheriv(SYMMETRIC_ALGO, passphrase, nonce);
+
+        decipher.setAuthTag(authTag);
+
+        return decipher;
     }
 
     async encrypt (data: Buffer): Promise<Buffer> {
-        return crypto.publicEncrypt(await this.keys.generatePublicKey(), data);
+        const cipher = await this._createCipher();
+
+        const result = Buffer.concat([cipher.update(data), cipher.final()]);
+
+        await this._saveAuthTag(cipher.getAuthTag());
+
+        return result;
     }
 
     async decrypt (data: Buffer): Promise<Buffer> {
-        return crypto.privateDecrypt(await this.keys.generatePrivateKey(), data);
+        const decipher = await this._createDecipher();
+
+        return Buffer.concat([decipher.update(data), decipher.final()]);
     }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,27 +1,44 @@
-class BaseError extends Error {
-    public readonly type: string;
+import * as TEXTS from './texts.js';
+import { Template } from './utils/template.js';
 
-    constructor (message: string, type: string) {
-        super(message);
 
-        this.type = type;
+export enum CODES {
+    E001 = 1,
+    E002,
+    E003
+}
+
+type RAU = ReadonlyArray<unknown>;
+
+abstract class BaseError<T extends ReadonlyArray<unknown>> extends Error {
+    public abstract code: CODES;
+    public abstract template: Template<T>;
+    private args: T;
+
+    public constructor (...args: T) {
+        super();
+        
+        this.name = new.target.name;
+        this.args = args;
+    }
+
+    public get message () {
+        return this.template.format(...this.args);
     }
 }
 
-export class LoadedDataInvalid extends BaseError {
-    constructor () {
-        super('Cannot validate the loaded data. It may be corrupt. Restore the data from backup or regenerate it.', 'E0');
-    }
+export class LoadedDataInvalid<T extends RAU> extends BaseError<T> {
+    code = CODES.E001;
+    template = TEXTS.LOADED_DATA_INVALID;
 }
 
-export class SavedDataNotDetected extends BaseError {
-    constructor () {
-        super('Cannot detect the saved data. Make sure the data was saved before loading.', 'E1');
-    }
+
+export class SavedDataNotDetected<T extends RAU> extends BaseError<T> {
+    code = CODES.E002;
+    template = TEXTS.SAVED_DATA_NOT_DETECTED;
 }
 
-export class MultipleSavedDataNotDetected extends BaseError {
-    constructor () {
-        super('Multiple variants of the saved data detected. Restore the data from backup or regenerate it.', 'E2');
-    }
+export class MultipleSavedDataDetected<T extends RAU> extends BaseError<T> {
+    code = CODES.E003;
+    template = TEXTS.MULTIPLE_SAVED_DATA_DETECTED;
 }

--- a/src/texts.ts
+++ b/src/texts.ts
@@ -1,0 +1,5 @@
+import { T } from './utils/template.js';
+
+export const LOADED_DATA_INVALID          = T('Cannot validate the loaded data. It may be corrupt. Restore the data from backup or regenerate it.');
+export const SAVED_DATA_NOT_DETECTED      = T('Cannot detect the saved data. Make sure the data was saved before loading.');
+export const MULTIPLE_SAVED_DATA_DETECTED = T('Multiple variants of the saved data detected. Restore the data from backup or regenerate it.');

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "outDir": "../lib",
         "declaration": true,
-        "sourceMap": true
+        "inlineSourceMap": true
     }
-}
+}

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -1,0 +1,24 @@
+type TemplateLambda<T extends ReadonlyArray<unknown>> = (...args: T) => string;
+
+export class Template<T extends ReadonlyArray<unknown>> {
+    private template: TemplateLambda<T>;
+
+    protected constructor (t: TemplateLambda<T>) {
+        this.template = t;
+    }
+
+    static create<T extends ReadonlyArray<unknown>> (x: string | TemplateLambda<T>): Template<T> {
+        if (typeof x === 'string')
+            return new Template(() => x);
+
+        return new Template(x);
+    }
+
+    format (...args: T): string {
+        return this.template(...args);
+    }
+}
+
+export function T <TT extends ReadonlyArray<unknown>> (x: string | TemplateLambda<TT>): Template<TT> {
+    return Template.create(x);
+}

--- a/test/src/file.ts
+++ b/test/src/file.ts
@@ -20,7 +20,8 @@ describe('File', () => {
             await load(FILE_TYPE.STORAGE);
         }
         catch (error: any) {
-            assert.match(error.type, /E1/);
+            assert.strictEqual(error.code, 2);
+            assert.strictEqual(error.message, 'Cannot detect the saved data. Make sure the data was saved before loading.');
         }
     });
 
@@ -41,7 +42,8 @@ describe('File', () => {
             await load(FILE_TYPE.STORAGE);
         }
         catch (error: any) {
-            assert.match(error.type, /E2/);
+            assert.strictEqual(error.code, 3);
+            assert.strictEqual(error.message, 'Multiple variants of the saved data detected. Restore the data from backup or regenerate it.');
         }
     });
 });

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
-import SafeStorage from '../../lib/index.js';
+import crypto from 'crypto';
+import proxyquire from 'proxyquire';
+import { SafeStorage, errors } from '../../lib/index.js';
 
 
 describe('Storage', function () {
@@ -8,11 +10,14 @@ describe('Storage', function () {
     it('Should save and load', async () => {
         const storage = new SafeStorage();
 
-        await storage.save({ foo: 'bar' });
+        // NOTE: bar should be large enough to detect issues with asymmetric key size restrictions
+        const bar = crypto.randomBytes(8000).toString('base64');
+
+        await storage.save({ foo: bar });
 
         const data: any = await storage.load();
 
-        assert.deepEqual(data.foo, 'bar');
+        assert.deepEqual(data.foo, bar);
     });
 
     it('Should throw an error when validation fails', async () => {
@@ -25,7 +30,54 @@ describe('Storage', function () {
             throw new Error('This should not be executed');
         }
         catch (error: any) {
-            assert.match(error.type, /E0/);
+            assert.strictEqual(error.code, 1);
+            assert.strictEqual(error.message, 'Cannot validate the loaded data. It may be corrupt. Restore the data from backup or regenerate it.');
         }
+    });
+
+    describe('tryLoad', () => {
+        const { SafeStorage: LocalSafeStorage } = proxyquire('../../lib/index.js', {
+            './file.js': {
+                load () {
+                    throw new errors.SavedDataNotDetected();
+                },
+            },
+        });
+
+        it('Should return undefined value when storage does not exist (default options)', async () => {
+            const storage = new LocalSafeStorage();
+
+            const result = await storage.tryLoad();
+
+            assert.strictEqual(result, void 0);
+        });
+
+        it('Should suppress errors by a code', async () => {
+            const storage = new LocalSafeStorage();
+
+            const result = await storage.tryLoad({ suppress: [errors.CODES.E002] });
+
+            assert.strictEqual(result, void 0);
+        });
+
+        it('Should not suppress unexpected errors', async () => {
+            const { SafeStorage: VeryLocalSafeStorage } = proxyquire('../../lib/index.js', {
+                './file.js': {
+                    load () {
+                        throw 'foobar';
+                    },
+                },
+            });
+
+            const storage = new VeryLocalSafeStorage();
+
+            try {
+                await storage.tryLoad({ suppress: [errors.CODES.E002] });
+                throw new Error('This path should throw');
+            }
+            catch (error: any) {
+                assert.strictEqual(error, 'foobar');
+            }
+        });
     });
 });

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "CommonJS",
     "moduleResolution": "Node",
     "esModuleInterop": true,


### PR DESCRIPTION
 * Added the tryLoad method: it allows to suppress specified errors, and return some default value in this case. By default, it ignores errors that happen when storage files do not exist and returns `undefined` if this happens. 
 
 * Reworked cryptography to allow bigger saved data. Now we use the synchronous AES-256-GCM cipher to encrypt and decrypt the data. The passphrase for the data is encrypted with an ephemeral key pair. The private key is also encrypted. The passphrase for the private key is random and is also used as an initialization vector when encrypting/decrypting the target data.  