### PR TITLE
fix: throw correct error when storage dir doesn't exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
 import CryptoContext from './crypto.js';
 
 import * as errors from './errors.js';
+import hasErrorCode from './utils/has-error-code.js';
 
 
 type ErrorSuppressor = errors.CODES | Function;
@@ -22,20 +23,12 @@ function defaultValidator<T> (a: unknown): a is T {
     return true;
 }
 
-function hasCode(error: unknown): error is { code: unknown } {
-    if (typeof error !== 'object' || !error)
-        return false;
-    
-    return 'code' in error;
-}
-
 function shouldSuppressError (error: unknown, suppressor: ErrorSuppressor) {    
     if (typeof suppressor === 'function') 
         return error instanceof suppressor;
 
-    if (hasCode(error))
+    if (hasErrorCode(error))
         return error.code === suppressor;
-    
 
     return false;
 }

--- a/src/utils/has-error-code.ts
+++ b/src/utils/has-error-code.ts
@@ -1,0 +1,6 @@
+export default function hasErrorCode (error: unknown): error is { code: unknown } {
+    if (typeof error !== 'object' || !error)
+        return false;
+
+    return 'code' in error;
+}

--- a/test/src/file.ts
+++ b/test/src/file.ts
@@ -25,6 +25,50 @@ describe('File', () => {
         }
     });
 
+    it('"load" should throw an error when the target dir cannot be read', async () => {
+        const { load, FILE_TYPE } = proxyquire('../../lib/file.js', {
+            'fs': {
+                promises: {
+                    readFile:  () => Promise.resolve(Buffer.from('')),
+                    writeFile: () => Promise.resolve(),
+                    rm:        () => Promise.resolve(),
+
+                    readdir: () => Promise.reject(Object.assign(new Error('Does not exist'), { code: 'ENOENT' })),
+                },
+            },
+        });
+
+        try {
+            await load(FILE_TYPE.STORAGE);
+        }
+        catch (error: any) {
+            assert.strictEqual(error.code, 2);
+            assert.strictEqual(error.message, 'Cannot detect the saved data. Make sure the data was saved before loading.');
+        }
+    });
+
+    it('"load" should rethrow an exisiting error when there is some other problem with the target dir', async () => {
+        const { load, FILE_TYPE } = proxyquire('../../lib/file.js', {
+            'fs': {
+                promises: {
+                    readFile:  () => Promise.resolve(Buffer.from('')),
+                    writeFile: () => Promise.resolve(),
+                    rm:        () => Promise.resolve(),
+
+                    readdir: () => Promise.reject(Object.assign(new Error('Access denied'), { code: 'EACCESS' })),
+                },
+            },
+        });
+
+        try {
+            await load(FILE_TYPE.STORAGE);
+        }
+        catch (error: any) {
+            assert.strictEqual(error.code, 'EACCESS');
+            assert.strictEqual(error.message, 'Access denied');
+        }
+    });
+
     it('"load" should throw an error when there are multiple stores', async () => {
         const { load, FILE_TYPE } = proxyquire('../../lib/file.js', {
             'fs': {


### PR DESCRIPTION
We should detect the situation when we try to read the storage file from a non-existent dir and throw `SavedDataNotFoundError` in this case. This way `tryLoad` will be able to suppress it with default options.