### PR TITLE
fix: overrode lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2520,9 +2520,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -6223,7 +6223,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -6544,9 +6544,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.merge": {
@@ -7126,7 +7126,7 @@
         "elegant-status": "1.1.0",
         "inquirer": "6.2.0",
         "is-ci": "1.2.1",
-        "lodash": "4.17.20",
+        "lodash": "^4.17.21",
         "micromatch": "3.1.10",
         "node-emoji": "1.8.1",
         "osenv": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "author": "DevExpress",
   "license": "MIT",
+  "overrides": {
+    "lodash": "^4.17.21"
+  },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.23",


### PR DESCRIPTION
[closes DevExpress/testcafe-private#121]

Module publish-please uses old version `lodash` with vulnerability. It should be fixed.